### PR TITLE
Fix Youtube seekTo method conflicting with unstarted and unmuted video

### DIFF
--- a/src/providers/youtube/youtube.ts
+++ b/src/providers/youtube/youtube.ts
@@ -226,6 +226,13 @@ export default function (Player: any) {
 		 * @param {Number} Current time video
 		 */
 		methodSeekTo(newTime: number) {
+			// Youtube triggers the play when the video is not yet started
+			// Video should be muted according to autoplay policy
+			if (this.isPaused === null && !this.options.muted) {
+				this.mute()
+				this.play()
+			}
+
 			this.instance.seekTo(newTime)
 
 			// The function can be trigger by the tabulation and Youtube does not have the "timeupdate" event

--- a/src/vlite/assets/scripts/player.ts
+++ b/src/vlite/assets/scripts/player.ts
@@ -295,7 +295,7 @@ export default class Player {
 	 * Play the media element
 	 */
 	play() {
-		if (this.elements.container.classList.contains('v-firstStart')) {
+		if (this.isPaused === null) {
 			this.elements.container.classList.remove('v-firstStart')
 
 			if (this.type === 'video' && this.elements.poster) {


### PR DESCRIPTION
Fixed #74.

Doc: https://developers.google.com/youtube/iframe_api_reference#seekTo
> Seeks to a specified time in the video. If the player is paused when the function is called, it will remain paused. If the function is called from another state (playing, video cued, etc.), the player will play the video.
