### PR TITLE
fix: Added initial aria-label for bigPlay component

### DIFF
--- a/src/components/big-play/big-play.ts
+++ b/src/components/big-play/big-play.ts
@@ -6,5 +6,5 @@ import svgBigPlay from 'shared/assets/svgs/big-play.svg'
  * @returns Generated HTML
  */
 export default function bigPlay(): string {
-	return `<button class="v-bigPlay">${svgBigPlay}</button>`
+	return `<button class="v-bigPlay" aria-label="Play">${svgBigPlay}</button>`
 }


### PR DESCRIPTION
This PR contains a: bigPlay button doesn't have initial aria-label="Play". It will only added when user clicked play or pause. but must have.

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case


### Breaking Changes


### Additional Info
