### PR TITLE
Fix the destroy method

### DIFF
--- a/src/core/player.ts
+++ b/src/core/player.ts
@@ -529,6 +529,7 @@ export default class Player {
 		this.playerEvents.forEach((event) => {
 			this.elements.container.removeEventListener(event.type, event.listener)
 		})
-		this.elements.container.remove()
+		this.media.classList.remove('v-media')
+		this.elements.outerContainer.replaceWith(this.media)
 	}
 }


### PR DESCRIPTION
<!--
  Please place an x (without) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->
destroy() method should remove all traces of the plugin and restore the media element to its original state.
 At the moment it just removes the container element (with video element itself) which is not an expected behavior
 
### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->
Potentially breaking in those cases where users expected such destroy() behavior and wrote code which interacts with outerContainer after destroy method was called

### Additional Info
