### PR TITLE
Remove useless v-fullscreenButtonDisplay class

### DIFF
--- a/src/core/player.ts
+++ b/src/core/player.ts
@@ -489,7 +489,7 @@ export default class Player {
 			// @ts-ignore: Object is possibly 'null'.
 			this.elements.container[requestFn]()
 			this.isFullScreen = true
-			this.elements.outerContainer.classList.add('v-fullscreenButtonDisplay')
+			this.elements.outerContainer.classList.add('v-fullscreen')
 
 			if (this.elements.fullscreen) {
 				this.elements.fullscreen.classList.add('v-controlPressed')
@@ -513,7 +513,7 @@ export default class Player {
 			!escKey && document[cancelFn]()
 			this.isFullScreen = false
 
-			this.elements.outerContainer.classList.remove('v-fullscreenButtonDisplay')
+			this.elements.outerContainer.classList.remove('v-fullscreen')
 
 			if (this.elements.fullscreen) {
 				this.elements.fullscreen.classList.remove('v-controlPressed')

--- a/src/core/vlite.css
+++ b/src/core/vlite.css
@@ -60,7 +60,7 @@
 		.v-controlBar,
 		.v-bigPlay {
 			position: fixed;
-			z-index: 2147483647;
+			z-index: 8;
 		}
 	}
 

--- a/src/core/vlite.css
+++ b/src/core/vlite.css
@@ -56,14 +56,6 @@
 		display: none !important;
 	}
 
-	&.v-fullscreenButtonDisplay {
-		.v-controlBar,
-		.v-bigPlay {
-			position: fixed;
-			z-index: 8;
-		}
-	}
-
 	&.v-paused {
 		.v-controlBar.v-hidden {
 			opacity: 1;


### PR DESCRIPTION
~~The `v-fullscreenButtonDisplay` component can use latest `z-index` instead of `2147483647`.~~

~~Merge after #155 is merged.~~

`v-fullscreenButtonDisplay` class is useless, remove it.

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
~~Improve `z-index` value logic and reduce size.~~