### PR TITLE
Prevent vertical scoll page on the volume hotkeys

### DIFF
--- a/src/plugins/hotkeys/hotkeys.ts
+++ b/src/plugins/hotkeys/hotkeys.ts
@@ -83,7 +83,7 @@ export default class Hotkeys {
 				activeElement === this.player.elements.volume)
 		) {
 			// Increase or decrease volume with arrow keys
-			e.preventDefault() // Prevent the scroll of the page
+			e.preventDefault() // Prevent the vertical scroll of the page
 
 			keyCode === 38 ? this.increaseVolume() : this.decreaseVolume()
 		}

--- a/src/plugins/hotkeys/hotkeys.ts
+++ b/src/plugins/hotkeys/hotkeys.ts
@@ -83,6 +83,8 @@ export default class Hotkeys {
 				activeElement === this.player.elements.volume)
 		) {
 			// Increase or decrease volume with arrow keys
+			e.preventDefault() // Prevent the scroll of the page
+
 			keyCode === 38 ? this.increaseVolume() : this.decreaseVolume()
 		}
 


### PR DESCRIPTION
When a volume hotkey was used, the page will scroll into the same direction of the directional key pressed.
Fix and disable this default behavior.

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**