### PR TITLE
Add support for custom controls in control bar

### DIFF
--- a/src/components/control-bar/control-bar.ts
+++ b/src/components/control-bar/control-bar.ts
@@ -136,6 +136,10 @@ export default class ControlBar {
 	onClickOnControlBar(e: Event) {
 		const target = e.target
 
+        if (target instanceof HTMLElement && target.classList.contains("v-customControlButton")) {
+            return;
+        }
+
 		const validateTargetPlayPauseButton = validateTarget({
 			target,
 			selectorString: '.v-playPauseButton',


### PR DESCRIPTION
<!--
  Please place an x (without) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**


Hey there 👋  
Thanks for this awesome library!

I discovered this player because [rubyevents.org](https://www.rubyevents.org/) uses it. 
On rubyevents.org, there is a [custom implementation](https://github.com/rubyevents/rubyevents/pull/75/files) for setting playback speed. This is done by adding a select element to the control bar and calling the player instance `setPlaybackRate` method.

While this works well, there is a small issue where the select dropdown closes automatically when clicked in some browsers. There is a related issue on the rubyevents repo, [here](https://github.com/rubyevents/rubyevents/issues/757).

The problem seems to be caused by the [`onClickOnControlBar`](https://github.com/vlitejs/vlite/blob/f644617bd5d54dca026bdd355ee72dd745d459a2/src/components/control-bar/control-bar.ts#L136) event listener. This listener triggers when the custom `<select>` element is clicked and tries to hide the control bar by focusing the container element:
```js
// Hide controls with timer after clicks
this.player.elements.container.focus()
```

This focus causes the playback speed select dropdown to close prematurely.

---

This PR would skip the `onClickOnControlBar` behaviour when the click target has a `v-customControlButton` class. 
This would allow us to add custom control elements that are independent of the default control bar functionality.
I’d love to hear your thoughts on this approach. Also, I'm also not sure if `v-customControlButton` is the best class name for this purpose.

